### PR TITLE
Add target="_blank" to press links

### DIFF
--- a/src/shared/components/Press.jsx
+++ b/src/shared/components/Press.jsx
@@ -7,7 +7,7 @@ export default class Press extends React.Component {
       if (typeof pressItem === 'string') {
         content = <span>{pressItem}</span>
       } else if (pressItem.url) {
-        content = <a href={pressItem.url}>{pressItem.source}</a>
+        content = <a href={pressItem.url} target="_blank" rel="noopener noreferrer">{pressItem.source}</a>
       } else {
         content = <span>{pressItem.source}</span>
       }


### PR DESCRIPTION
Haven't tested the change.

See the following for `rel="noreferrer..."` bit: https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-target-blank.md

Embarrassed to admit I was clicking through press links on your site...
